### PR TITLE
Updates for Xcode 12

### DIFF
--- a/Sources/Rorschach/Builders/TestBuilder.swift
+++ b/Sources/Rorschach/Builders/TestBuilder.swift
@@ -9,11 +9,11 @@ import Foundation
 
 @_functionBuilder public struct TestBuilder<C> {
 
-    static public func buildBlock(_ given: Given<C>, _ when: When<C>, _ then: Then<C>) -> (Given<C>, When<C>, Then<C>) {
+    public static func buildBlock(_ given: Given<C>, _ when: When<C>, _ then: Then<C>) -> (Given<C>, When<C>, Then<C>) {
         return (given, when, then)
     }
 
-    static public func buildBlock(_ when: When<C>, _ then: Then<C>) -> (When<C>, Then<C>) {
+    public static func buildBlock(_ when: When<C>, _ then: Then<C>) -> (When<C>, Then<C>) {
         return (when, then)
     }
 }

--- a/Sources/Rorschach/Builders/ThenBuilder.swift
+++ b/Sources/Rorschach/Builders/ThenBuilder.swift
@@ -8,9 +8,8 @@
 import Foundation
 
 
-@_functionBuilder struct ThenBuilder<C> {
-
-    static func buildBlock(_ assertion: Assertion<C>) -> Assertion<C> {
+@_functionBuilder public struct ThenBuilder<C> {
+    public static func buildBlock(_ assertion: Assertion<C>) -> Assertion<C> {
         assertion
     }
 }

--- a/Sources/Rorschach/When.swift
+++ b/Sources/Rorschach/When.swift
@@ -10,15 +10,17 @@ import XCTest
 
 public struct When<C> {
 
-    let step: Step<C>
+    let steps: [Step<C>]
 
-    public init(@WhenBuilder<C> _ content: () -> Step<C>) {
-        step = content()
+    public init(@WhenBuilder<C> _ content: () -> [Step<C>]) {
+        steps = content()
     }
 
     func execute(in context: inout C) {
-        XCTContext.runActivity(named: step.title) { activity in
-            step.execute(in: &context)
+        steps.forEach { step in
+            XCTContext.runActivity(named: step.title ) { _ in
+                step.execute(in: &context)
+            }
         }
     }
 }


### PR DESCRIPTION
I was playing with some function builder use cases and I really liked the idea of this package.
If you're interested I gave it a bit of TLC.

Corrected what I think might have been is a breaking language construct between Xcode 12 and 11 (or whatever those swift versions are exactly.

I also just made the access modifiers more consistent.

I do not know if this works correctly in Xcode 11.x, but I'm not sure if that's a guarantee regardless based on where function builders are currently in the language design.